### PR TITLE
Fix client using previous server pubkey when started before server

### DIFF
--- a/src/core/app/game_client.cpp
+++ b/src/core/app/game_client.cpp
@@ -159,7 +159,10 @@ void GameClient::networkThread()
         }
 
         netClient.ConsumeNetworkRequests([&](NetworkRequest* aEvent) {
-            // write header
+            if (aEvent->Type == PacketType::Auth) {
+                netClient.ResetSession();
+            }
+
             BitOutputArchive archive;
 
             aEvent->Archive(archive);
@@ -339,6 +342,24 @@ void GameClient::StartGameInstance(
     fixedExec.Register<NetworkResponseSystem>();
 }
 
+void GameClient::SendAuthRequest()
+{
+    auto& pbase     = mRegistry.ctx().get<PocketBaseClient>();
+    auto& netClient = mRegistry.ctx().get<ENetClient&>();
+
+    auto* req = new NetworkRequest{
+        .Type     = PacketType::Auth,
+        .PlayerID = 0,
+        .Tick     = 0,
+        .Payload =
+            AuthRequest{
+                .Token     = pbase.Token,
+                .HasAESNI  = sodium_runtime_has_aesni() != 0,
+                .PublicKey = netClient.RawPublicKey()},
+    };
+    netClient.EnqueueRequest(req);
+}
+
 void GameClient::consumeNetworkResponses()
 {
     struct NetworkResponseVisitor {
@@ -350,18 +371,23 @@ void GameClient::consumeNetworkResponses()
         {
             WATO_INFO(*Reg, "got connected response");
 
-            auto& pb        = Reg->ctx().get<PocketBaseClient>();
-            auto& netClient = Reg->ctx().get<ENetClient&>();
+            Client->SendAuthRequest();
+        }
 
-            auto* req     = new NetworkRequest;
-            req->Type     = PacketType::Auth;
-            req->PlayerID = 0;
-            req->Tick     = 0;
-            req->Payload  = AuthRequest{
-                 .Token     = pb.Token,
-                 .HasAESNI  = sodium_runtime_has_aesni() != 0,
-                 .PublicKey = netClient.RawPublicKey()};
-            netClient.EnqueueRequest(req);
+        void operator()(const ErrorResponse& aResp) const
+        {
+            if (aResp.Error == ServerError::HandshakeOpenSeal) {
+                WATO_ERR(*Reg, "got error response");
+                auto r = Reg->ctx().get<PocketBaseClient&>().GetGameServer("0.0.0.0", 7777);
+                if (!r) {
+                    WATO_ERR(*Reg, "cannot get game server");
+                    return;
+                }
+
+                WATO_DBG(*Reg, "got server public key = {}", r->publicKey);
+                Reg->ctx().get<ENetClient&>().SetServerPK(KeyFromB64<32>(r->publicKey));
+                Client->SendAuthRequest();
+            }
         }
 
         void operator()(const NewGameResponse& aResp) const

--- a/src/core/app/game_client.hpp
+++ b/src/core/app/game_client.hpp
@@ -91,6 +91,7 @@ class GameClient : public Application
 
     void Init() override;
     int  Run(tf::Executor& aExecutor) override;
+    void SendAuthRequest();
 
    protected:
     void StartGameInstance(

--- a/src/core/crypto/session.cpp
+++ b/src/core/crypto/session.cpp
@@ -29,6 +29,9 @@ byte_view CryptoSession::Encrypt(byte_view aBytes)
 
 byte_view CryptoSession::Decrypt(byte_view aBytes)
 {
+    const auto minSize = mAEAD->NonceBytes + mAEAD->AuthTagBytes;
+    if (aBytes.size() < minSize + 1) return {};
+
     byte_view nonce      = aBytes.subspan(0, mAEAD->NonceBytes);
     byte_view cipherText = aBytes.subspan(mAEAD->NonceBytes, aBytes.size() - mAEAD->NonceBytes);
 

--- a/src/core/crypto/session.hpp
+++ b/src/core/crypto/session.hpp
@@ -42,6 +42,7 @@ class CryptoSession
     }
 
     bool Valid() const { return mValid; }
+    void Reset() { mValid = false; }
 
     byte_view Encrypt(byte_view aBytes);
     byte_view Decrypt(byte_view aBytes);

--- a/src/core/net/enet_base.cpp
+++ b/src/core/net/enet_base.cpp
@@ -32,26 +32,30 @@ void ENetBase::Init()
     }
 }
 
-bool ENetBase::Send(ENetPeer* aPeer, const std::span<const uint8_t> aData)
+bool ENetBase::Send(ENetPeer* aPeer, std::span<const uint8_t> aData, bool aEncrypt)
 {
     if (aPeer == nullptr) {
         mLogger->debug("client peer not initialized");
         return false;
     }
 
-    auto* state = static_cast<PeerState*>(aPeer->data);
-    if (!state || !state->SecureSession.Valid()) {
-        mLogger->error("Peer not initialized or session not established");
-        return false;
-    }
+    byte_buffer data;
+    if (aEncrypt) {
+        auto* state = static_cast<PeerState*>(aPeer->data);
+        if (!state || !state->SecureSession.Valid()) {
+            mLogger->error("Peer not initialized or session not established");
+            return false;
+        }
 
-    byte_view enc = state->SecureSession.Encrypt(aData);
-    if (enc.empty()) {
-        mLogger->error("Could not encrypt peer data");
-        return false;
+        byte_view enc = state->SecureSession.Encrypt(aData);
+        if (enc.empty()) {
+            mLogger->error("Could not encrypt peer data");
+            return false;
+        }
+        data = byte_buffer(enc.begin(), enc.end());
+    } else {
+        data = byte_buffer(aData.begin(), aData.end());
     }
-
-    auto data = byte_buffer(enc.begin(), enc.end());
 
     ENetPacket* packet = enet_packet_create(data.data(), data.size(), ENET_PACKET_FLAG_RELIABLE);
 
@@ -110,14 +114,23 @@ void ENetBase::Poll()
                 }
 
                 if (state->SecureSession.Valid()) {
-                    byte_view decrypted = state->SecureSession.Decrypt(
-                        {event.packet->data, event.packet->dataLength});
+                    byte_view raw{event.packet->data, event.packet->dataLength};
+                    byte_view decrypted = state->SecureSession.Decrypt(raw);
                     if (decrypted.empty()) {
-                        mLogger->error("Could not decrypt data");
+                        if (state->AwaitingHandshake) {
+                            // Handshake failed server-side — error sent unencrypted
+                            mLogger->warn("Decrypt failed during handshake, trying raw");
+                            OnReceive(event, raw);
+                        } else {
+                            mLogger->error("Could not decrypt data");
+                        }
                         enet_packet_destroy(event.packet);
                         break;
                     }
 
+                    if (state->AwaitingHandshake) {
+                        state->AwaitingHandshake = false;
+                    }
                     OnReceive(event, decrypted);
                 } else {
                     OnReceive(event, {event.packet->data, event.packet->dataLength});

--- a/src/core/net/enet_base.hpp
+++ b/src/core/net/enet_base.hpp
@@ -14,6 +14,7 @@
 
 struct PeerState {
     PlayerID ID{0};
+    bool     AwaitingHandshake{false};
 
     CryptoSession SecureSession{};
     PublicKey     PeerPK{};
@@ -56,7 +57,7 @@ class ENetBase
     void EnqueueRequest(NetworkRequest* aEvent) { mReqChannel.Send(aEvent); }
 
    protected:
-    bool Send(ENetPeer* aPeer, const std::span<const uint8_t> aData);
+    bool Send(ENetPeer* aPeer, std::span<const uint8_t> aData, bool aEncrypt = true);
 
     virtual void OnConnect(ENetEvent& aEvent)                  = 0;
     virtual void OnReceive(ENetEvent& aEvent, byte_view aData) = 0;

--- a/src/core/net/enet_client.cpp
+++ b/src/core/net/enet_client.cpp
@@ -86,6 +86,7 @@ void ENetClient::Send(std::span<const uint8_t> aData)
         // Init session keys for subsequent AEAD traffic
         bool hasAESNI = sodium_runtime_has_aesni() != 0;
         state->SecureSession.Init(mKeys, state->PeerPK.Raw(), hasAESNI, false);
+        state->AwaitingHandshake = true;
     } else {
         ENetBase::Send(mPeer, aData);
     }

--- a/src/core/net/enet_client.hpp
+++ b/src/core/net/enet_client.hpp
@@ -30,6 +30,17 @@ class ENetClient : public ENetBase
 
     void SetServerPK(const CryptoKeys::Public& aPubKey) { mServerPK = PublicKey(aPubKey); }
 
+    // Must be called from the network thread
+    void ResetSession()
+    {
+        if (mPeer != nullptr && mPeer->data != nullptr) {
+            auto* state = static_cast<PeerState*>(mPeer->data);
+            state->SecureSession.Reset();
+            state->PeerPK            = mServerPK;
+            state->AwaitingHandshake = false;
+        }
+    }
+
    protected:
     void OnConnect(ENetEvent& aEvent) override;
     /**

--- a/src/core/net/enet_server.cpp
+++ b/src/core/net/enet_server.cpp
@@ -68,6 +68,22 @@ void ENetServer::OnReceive(ENetEvent& aEvent, byte_view aData)
         byte_view decrypted = mKeys.Decrypt(aData);
         if (decrypted.empty()) {
             mLogger->error("Could not open sealed handshake");
+            BitOutputArchive out;
+            NetworkResponse  resp{
+                 .Type     = PacketType::Nack,
+                 .PlayerID = 0,
+                 .Tick     = 0,
+                 .Payload  = ErrorResponse{.Error = ServerError::HandshakeOpenSeal}};
+
+            if (!resp.Archive(out)) {
+                mLogger->error("Could not archive error response");
+                return;
+            }
+
+            if (!ENetBase::Send(aEvent.peer, out.Bytes(), false)) {
+                mLogger->error("Could send error response");
+                return;
+            }
             return;
         }
         aData = decrypted;
@@ -96,11 +112,11 @@ void ENetServer::OnReceive(ENetEvent& aEvent, byte_view aData)
                     auto playerID = PlayerIDFromHexString(aResult->record.id);
                     if (playerID) {
                         chan.Send(new AuthResult{
-                            peer,
-                            *playerID,
-                            aResult->record.accountName,
-                            hasAESNI,
-                            pub});
+                            .Peer        = peer,
+                            .ID          = *playerID,
+                            .AccountName = aResult->record.accountName,
+                            .HasAESNI    = hasAESNI,
+                            .PublicKey   = pub});
                         return;
                     }
                 }
@@ -128,15 +144,16 @@ void ENetServer::ProcessAuthResults()
             return;
         }
 
-        auto* state    = static_cast<PeerState*>(aResult->Peer->data);
-        state->ID      = aResult->ID;
-        bool  canAEGIS = aResult->HasAESNI && (sodium_runtime_has_aesni() != 0);
+        auto* state   = static_cast<PeerState*>(aResult->Peer->data);
+        state->ID     = aResult->ID;
+        bool canAEGIS = aResult->HasAESNI && (sodium_runtime_has_aesni() != 0);
 
         state->SecureSession.Init(mKeys, aResult->PublicKey, canAEGIS, true);
         if (!state->SecureSession.Valid()) {
             mLogger->error("cannot compute server session keys");
             return;
         }
+        state->AwaitingHandshake = true;
 
         mConnectedPeers[aResult->ID] = aResult->Peer;
         mAccountNames[aResult->ID]   = aResult->AccountName;
@@ -152,7 +169,7 @@ void ENetServer::ProcessAuthResults()
             .Payload  = AuthResponse{.ID = aResult->ID, .HasAESNI = canAEGIS, .Success = true}};
         BitOutputArchive archive;
         resp.Archive(archive);
-        ENetBase::Send(aResult->Peer, archive.Bytes());
+        Send(resp.PlayerID, archive.Bytes());
     });
 }
 

--- a/src/core/net/net.hpp
+++ b/src/core/net/net.hpp
@@ -97,6 +97,22 @@ struct ConnectedResponse {
 
 inline bool operator==(const ConnectedResponse&, const ConnectedResponse&) { return true; }
 
+enum class ServerError : std::uint8_t {
+    Success,
+    HandshakeOpenSeal,
+};
+
+struct ErrorResponse {
+    ServerError Error{};
+
+    bool Archive(auto& aArchive)
+    {
+        return ArchiveValue(aArchive, Error, ServerError::Success, ServerError::HandshakeOpenSeal);
+    }
+
+    auto operator<=>(const ErrorResponse&) const = default;
+};
+
 enum class RigidBodyEvent : std::uint16_t {
     Create,
     Update,
@@ -330,6 +346,7 @@ enum class PacketType : std::uint16_t {
     ClientSync,
     ServerSync,
     Ack,
+    Nack,
     NewGame,
     Connected,
     Auth,
@@ -341,6 +358,7 @@ using NetworkResponsePayload = std::variant<
     std::monostate,
     NewGameResponse,
     ConnectedResponse,
+    ErrorResponse,
     SyncPayload,
     RigidBodyUpdateResponse,
     HealthUpdateResponse,
@@ -388,6 +406,10 @@ struct fmt::formatter<NetworkResponsePayload> : fmt::formatter<std::string> {
             void operator()(const ConnectedResponse&) const
             {
                 fmt::format_to(Ctx->out(), "connected response");
+            }
+            void operator()(const ErrorResponse& aResp) const
+            {
+                fmt::format_to(Ctx->out(), "error response: {}", uint8_t(aResp.Error));
             }
             void operator()(const SyncPayload& aResp) const
             {


### PR DESCRIPTION
Reproduce:
- server stopped
- launch client => fetches server PK from PocketBase (old PK)
- launch server => generates new PK, publishes to PocketBase
- client starts handshake with old PK, token sent in crypto box sealed can't be opened
- cannot start game

With fix, we send error back to client, then PK is refetched from PocketBase