### PR TITLE
Creep collision with base, log system tag and std::function replacement

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,20 +1,24 @@
 # WaTo
 
-3D PvP Tower Defense game built with C++20. Features client-server architecture with deterministic lockstep networking, custom bit-level serialization, and an ECS using EnTT.
+3D PvP Tower Defense game built with C++23. Inspired by Warcraft 3 TDs this is a project to learn game engine development.
+
+Features client/server binaries (enet + libsodium) with pocketbase user backend.
+
+bgfx is used for rendering.
 
 ## Getting Started
 
 ```bash
-git clone --recurse-submodules -j8 git@github.com:robinwils/wato.git
+git clone --recurse-submodules -j8 https://github.com/robinwils/wato.git
 cd wato
-git lfs pull
+git lfs pull # pull assets
 ```
 
 ## Prerequisites
 
 - CMake 3.29+
-- Ninja
-- C++20 compiler (GCC 12+, Clang 16+, or MSVC 17+)
+- Ninja/Make
+- C++23 compiler
 - Git LFS
 - vcpkg (included as submodule)
 
@@ -31,7 +35,7 @@ sudo apt-get install -y \
 ```
 
 `autoconf`, `automake`, `libtool` are needed by vcpkg to build libsodium from source.
-The `libvulkan-dev`, X11 and Wayland packages are only needed when building the client (`ENABLE_CLIENT=ON`).
+The `libvulkan-dev`, X11/Wayland packages are only needed when building the client (`ENABLE_CLIENT=ON`).
 
 ### macOS
 
@@ -46,7 +50,7 @@ brew install cmake ninja autoconf automake libtool
 
 1. Install [Visual Studio 2022](https://visualstudio.microsoft.com/) (Community or Build Tools) with the **"Desktop development with C++"** workload
 2. Install [CMake 3.29+](https://cmake.org/download/) and [Ninja](https://ninja-build.org/) (or via `choco install cmake ninja`)
-3. Install the [Vulkan SDK](https://vulkan.lunarg.com/sdk/home)
+3. Install the [Vulkan SDK](https://vulkan.lunarg.com/sdk/home) (version 1.4.328.1 at least)
 
 Run builds from a **Developer Command Prompt** (or use `vcvarsall.bat`) so MSVC is on PATH.
 
@@ -56,15 +60,15 @@ CMake presets handle all configuration:
 
 ```bash
 # Configure
-cmake --preset unixlike-gcc-debug        # Linux GCC
-cmake --preset unixlike-clang-debug      # Linux/macOS Clang
+cmake --preset linux-gcc-debug        # Linux GCC
+cmake --preset linux-clang-debug      # Linux/macOS Clang
 cmake --preset windows-msvc-debug        # Windows MSVC
 
 # Build
 cmake --build --preset <preset-name>
 ```
 
-Append `-sccache` to any preset name to use sccache (e.g. `unixlike-clang-debug-sccache`).
+Append `-sccache` to any preset name to use sccache (e.g. `linux-clang-debug-sccache`).
 
 Replace `debug` with `release` for optimized builds.
 

--- a/src/core/app/game_client.cpp
+++ b/src/core/app/game_client.cpp
@@ -294,7 +294,11 @@ void GameClient::StartGameInstance(Registry& aRegistry, const NewGameResponse& a
                         .IsTrigger = true,
                         .ShapeParams =
                             BoxShapeParams{
-                                .HalfExtents = GraphCell(1, 1).ToWorld() * 0.5f,
+                                // Must match the server base trigger (see game_server.cpp).
+                                .HalfExtents = glm::vec3(
+                                    GraphCell::kCellSize * 0.75f,
+                                    GraphCell::kCellSize * 0.5f,
+                                    GraphCell::kCellSize * 0.75f),
                             },
                     },
             });

--- a/src/core/app/game_server.cpp
+++ b/src/core/app/game_server.cpp
@@ -287,9 +287,11 @@ std::vector<PlayerInitData> GameServer::spawnPlayers(
         aRegistry.emplace<Gold>(player, mGameplayDef.Economy.StartingGold);
         WATO_INFO(aRegistry, "server player {} created", player);
 
-        auto& pTransform = aRegistry.emplace<Transform3D>(
+        // Offset by half a cell so the cell-aligned base trigger is centered on the dest cell.
+        constexpr float kHalfCell  = GraphCell::kCellSize * 0.5f;
+        auto&           pTransform = aRegistry.emplace<Transform3D>(
             player,
-            glm::vec3(2.0f + offset.x, 0.004f, 2.0f + offset.y));
+            glm::vec3(2.0f + kHalfCell + offset.x, 0.004f, 2.0f + kHalfCell + offset.y));
         aRegistry.emplace<RigidBody>(
             player,
             RigidBody{
@@ -314,7 +316,11 @@ std::vector<PlayerInitData> GameServer::spawnPlayers(
                         .IsTrigger = true,
                         .ShapeParams =
                             BoxShapeParams{
-                                .HalfExtents = GraphCell(1, 1).ToWorld() * 0.5f,
+                                // ~1.5 cells wide so a creep reaching the dest cell overlaps it.
+                                .HalfExtents = glm::vec3(
+                                    GraphCell::kCellSize * 0.75f,
+                                    GraphCell::kCellSize * 0.5f,
+                                    GraphCell::kCellSize * 0.75f),
                             },
                     },
             });

--- a/src/core/graph.hpp
+++ b/src/core/graph.hpp
@@ -22,6 +22,7 @@ struct GraphCell {
     GraphCell(const size_type aX, const size_type aY) : Location(aX, aY) {}
 
     constexpr static size_type kCellsPerAxis = 3;
+    constexpr static float     kCellSize     = 1.0f / GraphCell::kCellsPerAxis;
 
     constexpr glm::vec3 ToWorld(const glm::vec2& aOffset = {0, 0}) const
     {

--- a/src/core/graph.hpp
+++ b/src/core/graph.hpp
@@ -23,13 +23,15 @@ struct GraphCell {
 
     constexpr static size_type kCellsPerAxis = 3;
     constexpr static float     kCellSize     = 1.0f / GraphCell::kCellsPerAxis;
+    constexpr static float     kCellHeight   = 0.001f;
 
-    constexpr glm::vec3 ToWorld(const glm::vec2& aOffset = {0, 0}) const
+    /// World position of the cell's min corner (used for grid-line geometry).
+    [[nodiscard]] constexpr glm::vec3 ToWorld(const glm::vec2& aOffset = {0, 0}) const
     {
-        return glm::vec3(
-            Location.x / static_cast<float>(GraphCell::kCellsPerAxis) + aOffset.x,
-            0.001f,
-            Location.y / static_cast<float>(GraphCell::kCellsPerAxis) + aOffset.y);
+        return {
+            (static_cast<float>(Location.x) * kCellSize) + aOffset.x,
+            kCellHeight,
+            (static_cast<float>(Location.y) * kCellSize) + aOffset.y};
     }
 
     bool operator==(const GraphCell&) const = default;

--- a/src/core/net/pocketbase.cpp
+++ b/src/core/net/pocketbase.cpp
@@ -207,7 +207,7 @@ void PocketBaseClient::Update()
 
     auto now = std::chrono::steady_clock::now();
 
-    std::vector<std::function<void()>> toReconnect;
+    std::vector<const SSEState::reconnect_func*> toReconnect;
 
     for (auto& [name, state] : mSubscriptions) {
         if (!state.ShouldReconnect && state.SSEResponse.valid()
@@ -243,11 +243,15 @@ void PocketBaseClient::Update()
             state.StopSource      = std::make_shared<std::atomic<bool>>(false);
             state.SSEResponse     = state.Factory(state.StopSource);
             state.ShouldReconnect = false;
-            if (state.OnReconnect) toReconnect.push_back(state.OnReconnect);
+            if (state.OnReconnect) {
+                toReconnect.emplace_back(&state.OnReconnect);
+            }
         }
     }
 
-    for (auto& cb : toReconnect) cb();
+    for (auto& cb : toReconnect) {
+        (*cb)();
+    }
 }
 
 cpr::Header PocketBaseClient::AuthHeader(const std::string& aToken) const

--- a/src/core/net/pocketbase.hpp
+++ b/src/core/net/pocketbase.hpp
@@ -148,6 +148,22 @@ struct PBError {
 template <typename T>
 using PBCallback = std::function<void(std::expected<T, PBError>)>;
 
+using StopFlag = std::shared_ptr<std::atomic<bool>>;
+
+struct SSEState {
+    using reconnect_func = std::move_only_function<void() const>;
+    using factory_func   = std::move_only_function<cpr::AsyncResponse(StopFlag) const>;
+
+    StopFlag           StopSource{std::make_shared<std::atomic<bool>>(false)};
+    cpr::AsyncResponse SSEResponse{};
+
+    bool                                  ShouldReconnect{false};
+    std::chrono::steady_clock::time_point NextReconnect{};
+    std::chrono::milliseconds             BackoffMs{1000};
+    reconnect_func                        OnReconnect;
+    factory_func                          Factory;
+};
+
 /**
  * @brief Unified client for all PocketBase/backend operations
  *
@@ -190,10 +206,10 @@ class PocketBaseClient
 
     template <typename T>
     void Subscribe(
-        const std::string&    aSubscription,
-        Channel<PBSSE<T>>&    aChan,
-        const std::string&    aFields      = "",
-        std::function<void()> aOnReconnect = nullptr)
+        const std::string&       aSubscription,
+        Channel<PBSSE<T>>&       aChan,
+        const std::string&       aFields      = "",
+        SSEState::reconnect_func aOnReconnect = nullptr)
     {
         Unsubscribe(aSubscription);
 
@@ -320,19 +336,6 @@ class PocketBaseClient
         std::lock_guard lock(mAsyncMutex);
         mAsyncResponses.emplace_back(std::move(future));
     }
-
-    using StopFlag = std::shared_ptr<std::atomic<bool>>;
-
-    struct SSEState {
-        StopFlag           StopSource{std::make_shared<std::atomic<bool>>(false)};
-        cpr::AsyncResponse SSEResponse{};
-
-        bool                                              ShouldReconnect{false};
-        std::chrono::steady_clock::time_point             NextReconnect{};
-        std::chrono::milliseconds                         BackoffMs{1000};
-        std::function<void()>                             OnReconnect;
-        std::function<cpr::AsyncResponse(StopFlag)>       Factory;
-    };
 
     template <typename T>
     bool handleSSEEvent(

--- a/src/core/sys/log.hpp
+++ b/src/core/sys/log.hpp
@@ -71,7 +71,7 @@ inline Logger CreateLogger(const std::string& aName, const std::string& aLevel)
     // FIXME: weird segfault when using %s and %# instead of %@
     // or puting the thread info in separate []
     //
-    std::string loggerFormat = "[%H:%M:%S %z T %t] [%n] [%^%L%$] %v %@";
+    std::string loggerFormat = "[%H:%M:%S %z T %t] [%^%L%$] [%n] %v %@";
 
     consoleSink->set_pattern(loggerFormat);
     fileSink->set_pattern(loggerFormat);

--- a/src/systems/action.cpp
+++ b/src/systems/action.cpp
@@ -25,9 +25,12 @@
 #include "input/action.hpp"
 #include "registry/registry.hpp"
 
-void moveCamera(Registry& aRegistry, const MovePayload& aPayload, float aDeltaTime)
+void RealTimeActionSystem::moveCamera(
+    Registry&          aRegistry,
+    const MovePayload& aPayload,
+    float              aDeltaTime)
 {
-    WATO_TRACE(aRegistry, "moving camera {}", aDeltaTime);
+    mLogger->trace("moving camera {}", aDeltaTime);
     for (auto&& [entity, camera, transform] : aRegistry.view<Camera, Transform3D>().each()) {
         float const speed = camera.Speed * aDeltaTime;
 
@@ -60,23 +63,21 @@ void moveCamera(Registry& aRegistry, const MovePayload& aPayload, float aDeltaTi
     }
 }
 
-bool clientValidateTower(Registry& aRegistry, const BuildTowerPayload& aPayload)
+bool DeterministicActionSystem::clientValidateTower(
+    Registry&                aRegistry,
+    const BuildTowerPayload& aPayload)
 {
     auto&       phy   = GetSingletonComponent<Physics>(aRegistry);
     const auto& graph = GetSingletonComponent<Graph>(aRegistry);
 
     for (const auto&& [tower, pm, t] : aRegistry.view<PlacementMode, Transform3D>().each()) {
         if (!graph.IsInside(t.Position)) {
-            WATO_ERR(aRegistry, "trying to place tower outside map bounds.");
+            mLogger->error("trying to place tower outside map bounds.");
             continue;
         }
 
-        if (!CanPlaceTower(
-                phy,
-                t.Position,
-                TowerDef::kColliderParams,
-                WATO_REG_LOGGER(aRegistry))) {
-            WATO_ERR(aRegistry, "Cannot build tower at {}", t.Position);
+        if (!CanPlaceTower(phy, t.Position, TowerDef::kColliderParams, mLogger)) {
+            mLogger->error("Cannot build tower at {}", t.Position);
             return false;
         }
 
@@ -87,7 +88,10 @@ bool clientValidateTower(Registry& aRegistry, const BuildTowerPayload& aPayload)
     return true;
 }
 
-void serverBuildTower(Registry& aRegistry, BuildTowerPayload& aPayload, PlayerID aPlayerID)
+void ServerActionSystem::serverBuildTower(
+    Registry&          aRegistry,
+    BuildTowerPayload& aPayload,
+    PlayerID           aPlayerID)
 {
     auto& graphMap = GetSingletonComponent<PlayerGraphMap>(aRegistry);
     auto  it       = graphMap.find(aPlayerID);
@@ -96,17 +100,17 @@ void serverBuildTower(Registry& aRegistry, BuildTowerPayload& aPayload, PlayerID
     const auto  towerDefIt = defs.Towers.find(aPayload.Tower);
 
     if (it == graphMap.end()) {
-        WATO_ERR(aRegistry, "cannot find graph for target player {}", aPlayerID);
+        mLogger->error("cannot find graph for target player {}", aPlayerID);
         return;
     }
     const auto& graph = it->second;
     if (!graph.IsInside(aPayload.Position)) {
-        WATO_ERR(aRegistry, "trying to place tower outside map bounds.");
+        mLogger->error("trying to place tower outside map bounds.");
         return;
     }
 
     if (towerDefIt == defs.Towers.end()) {
-        WATO_ERR(aRegistry, "unknown tower type {}", TowerTypeToString(aPayload.Tower));
+        mLogger->error("unknown tower type {}", TowerTypeToString(aPayload.Tower));
         return;
     }
     const auto& towerDef = towerDefIt->second;
@@ -114,8 +118,7 @@ void serverBuildTower(Registry& aRegistry, BuildTowerPayload& aPayload, PlayerID
     auto  playerEntity = FindPlayerEntity(aRegistry, aPlayerID);
     auto& gold         = aRegistry.get<Gold>(playerEntity);
     if (gold.Balance < towerDef.Cost) {
-        WATO_ERR(
-            aRegistry,
+        mLogger->error(
             "player {} insufficient gold {} < {}",
             aPlayerID,
             gold.Balance,
@@ -133,9 +136,9 @@ void serverBuildTower(Registry& aRegistry, BuildTowerPayload& aPayload, PlayerID
 
     ColliderParams colliderParams = TowerDef::kColliderParams;
 
-    if (!CanPlaceTower(phy, t3D.Position, colliderParams, WATO_REG_LOGGER(aRegistry))) {
+    if (!CanPlaceTower(phy, t3D.Position, colliderParams, mLogger)) {
         aRegistry.destroy(tower);
-        WATO_ERR(aRegistry, "tower {} at {} invalidated", tower, t3D.Position);
+        mLogger->error("tower {} at {} invalidated", tower, t3D.Position);
         return;
     }
 
@@ -147,7 +150,7 @@ void serverBuildTower(Registry& aRegistry, BuildTowerPayload& aPayload, PlayerID
     body.Body       = phy.CreateRigidBody(body.Params, t3D);
     collider.Handle = phy.AddCollider(body.Body, colliderParams);
 
-    WATO_INFO(aRegistry, "tower {} at {} validated", tower, t3D.Position);
+    mLogger->info("tower {} at {} validated", tower, t3D.Position);
     aRegistry.emplace<Tower>(tower, aPayload.Tower);
     aRegistry.emplace<RigidBody>(tower, body);
     aRegistry.emplace<Collider>(tower, collider);
@@ -184,11 +187,14 @@ void serverBuildTower(Registry& aRegistry, BuildTowerPayload& aPayload, PlayerID
     }
 }
 
-void serverSendCreep(Registry& aRegistry, SendCreepPayload& aPayload, PlayerID aPlayerID)
+void ServerActionSystem::serverSendCreep(
+    Registry&         aRegistry,
+    SendCreepPayload& aPayload,
+    PlayerID          aPlayerID)
 {
     entt::entity nextSpawn = GetTargetSpawnFor(aRegistry, aPlayerID);
     if (nextSpawn == entt::null) {
-        WATO_ERR(aRegistry, "cannot find target spawn for player {}", aPlayerID);
+        mLogger->error("cannot find target spawn for player {}", aPlayerID);
         return;
     }
     const auto& creepDef = GetCreepDef(aRegistry, aPayload.Type);
@@ -197,8 +203,7 @@ void serverSendCreep(Registry& aRegistry, SendCreepPayload& aPayload, PlayerID a
     auto  playerEntity = FindPlayerEntity(aRegistry, aPlayerID);
     auto& gold         = aRegistry.get<Gold>(playerEntity);
     if (gold.Balance < creepDef.Cost) {
-        WATO_ERR(
-            aRegistry,
+        mLogger->error(
             "player {} insufficient gold {} < {}",
             aPlayerID,
             gold.Balance,
@@ -214,7 +219,7 @@ void serverSendCreep(Registry& aRegistry, SendCreepPayload& aPayload, PlayerID a
     auto  it       = graphMap.find(spawnOwner.ID);
 
     if (it == graphMap.end()) {
-        WATO_ERR(aRegistry, "cannot find graph for target player {}", spawnOwner.ID);
+        mLogger->error("cannot find graph for target player {}", spawnOwner.ID);
         return;
     }
     const auto& graph = it->second;
@@ -298,7 +303,7 @@ void RealTimeActionSystem::Execute(Registry& aRegistry, float aDelta)
         } else if (auto* placement = std::get_if<PlacementModePayload>(&action.Payload)) {
             stack.TogglePlacement(aRegistry, *placement);
         } else {
-            WATO_TRACE(aRegistry, "unhandled frame-time action: {}", action);
+            mLogger->trace("unhandled frame-time action: {}", action);
         }
     }
     buf.clear();
@@ -319,7 +324,7 @@ void DeterministicActionSystem::Execute(Registry& aRegistry, [[maybe_unused]] st
         } else if (std::get_if<SendCreepPayload>(&action.Payload)) {
             // client no-op, server handles
         } else {
-            WATO_TRACE(aRegistry, "unhandled fixed-time action: {}", action);
+            mLogger->trace("unhandled fixed-time action: {}", action);
         }
     }
 }
@@ -334,7 +339,7 @@ void ServerActionSystem::Execute(Registry& aRegistry, [[maybe_unused]] std::uint
         } else if (auto* creep = std::get_if<SendCreepPayload>(&action.Payload)) {
             serverSendCreep(aRegistry, *creep, playerID);
         } else {
-            WATO_TRACE(aRegistry, "unhandled server action: {}", action);
+            mLogger->trace("unhandled server action: {}", action);
         }
     }
     taggedActions.clear();

--- a/src/systems/action.hpp
+++ b/src/systems/action.hpp
@@ -3,11 +3,6 @@
 #include "input/action.hpp"
 #include "systems/system.hpp"
 
-void moveCamera(Registry& aRegistry, const MovePayload& aPayload, float aDeltaTime);
-bool clientValidateTower(Registry& aRegistry, const BuildTowerPayload& aPayload);
-void serverBuildTower(Registry& aRegistry, BuildTowerPayload& aPayload, PlayerID aPlayerID);
-void serverSendCreep(Registry& aRegistry, SendCreepPayload& aPayload, PlayerID aPlayerID);
-
 /**
  * @brief Real-time action system (frame time)
  *
@@ -23,6 +18,9 @@ class RealTimeActionSystem : public FrameSystem
 
    protected:
     void Execute(Registry& aRegistry, float aDelta) override;
+
+   private:
+    void moveCamera(Registry& aRegistry, const MovePayload& aPayload, float aDeltaTime);
 };
 
 /**
@@ -36,8 +34,13 @@ class DeterministicActionSystem : public FixedSystem
    public:
     using FixedSystem::FixedSystem;
 
+    const char* Name() const override { return "DeterministicActionSystem"; }
+
    protected:
     void Execute(Registry& aRegistry, std::uint32_t aTick) override;
+
+   private:
+    bool clientValidateTower(Registry& aRegistry, const BuildTowerPayload& aPayload);
 };
 
 /**
@@ -51,6 +54,12 @@ class ServerActionSystem : public FixedSystem
    public:
     using FixedSystem::FixedSystem;
 
+    const char* Name() const override { return "ServerActionSystem"; }
+
    protected:
     void Execute(Registry& aRegistry, std::uint32_t aTick) override;
+
+   private:
+    void serverBuildTower(Registry& aRegistry, BuildTowerPayload& aPayload, PlayerID aPlayerID);
+    void serverSendCreep(Registry& aRegistry, SendCreepPayload& aPayload, PlayerID aPlayerID);
 };

--- a/src/systems/ai.cpp
+++ b/src/systems/ai.cpp
@@ -19,6 +19,7 @@
 
 void AiSystem::Execute(Registry& aRegistry, [[maybe_unused]] std::uint32_t aTick)
 {
+    // only run on server
     auto& graphMap = GetSingletonComponent<PlayerGraphMap>(aRegistry);
 
     for (auto&& [e, creep, target, t, rb, p] :
@@ -26,7 +27,7 @@ void AiSystem::Execute(Registry& aRegistry, [[maybe_unused]] std::uint32_t aTick
         auto it = graphMap.find(target.ID);
 
         if (it == graphMap.end()) {
-            WATO_ERR(aRegistry, "cannot find player graph");
+            mLogger->error("cannot find player graph");
             continue;
         }
         const auto& graph = it->second;
@@ -36,22 +37,19 @@ void AiSystem::Execute(Registry& aRegistry, [[maybe_unused]] std::uint32_t aTick
         if (!p.NextCell || c == p.NextCell) {
             p.NextCell = graph.GetNextCell(c);
             p.LastFrom = c;
-            WATO_TRACE(aRegistry, "set next cell = {} and last from = {}", p.NextCell, p.LastFrom);
+            mLogger->trace("set next cell = {} and last from = {}", p.NextCell, p.LastFrom);
         } else if (p.NextCell != graph.GetNextCell(p.LastFrom)) {
             // the path has probably been updated (tower built)
-            WATO_TRACE(
-                aRegistry,
-                "path updated, setting next cell = ",
-                graph.GetNextCell(p.LastFrom));
+            mLogger->trace("path updated, setting next cell = ", graph.GetNextCell(p.LastFrom));
             p.NextCell = graph.GetNextCell(p.LastFrom);
         }
 
         aRegistry.patch<RigidBody>(e, [&p, &c](RigidBody& aBody) {
             if (p.NextCell) {
                 aBody.Params.Direction = glm::normalize(p.NextCell->ToWorld() - c.ToWorld());
-            } else {
-                aBody.Params.Velocity = 0.0f;
             }
+            // No next cell means the creep reached the last waypoint before the base.
+            // Keep the last direction so the physics body continues into the base collider.
         });
     }
 }

--- a/src/systems/ai.hpp
+++ b/src/systems/ai.hpp
@@ -13,6 +13,8 @@ class AiSystem : public FixedSystem
    public:
     using FixedSystem::FixedSystem;
 
+    const char* Name() const override { return "AiSystem"; }
+
    protected:
     void Execute(Registry& aRegistry, std::uint32_t aTick) override;
 };

--- a/src/systems/animation.cpp
+++ b/src/systems/animation.cpp
@@ -16,8 +16,7 @@ void AnimationSystem::Execute(Registry& aRegistry, const float aDelta)
         if (auto model = aRegistry.ctx().get<ModelCache>()[obj.ModelHash]; model) {
             if (!animator.Animation
                 && !(animator.Animation = model->GetAnimation(animator.AnimationName))) {
-                WATO_WARN(
-                    aRegistry,
+                mLogger->warn(
                     "could not get animation {}, ignoring",
                     animator.AnimationName);
                 continue;
@@ -25,7 +24,7 @@ void AnimationSystem::Execute(Registry& aRegistry, const float aDelta)
             const Skeleton& skeleton = model->Skeleton();
 
             if (skeleton.Bones.empty()) {
-                WATO_WARN(aRegistry, "got empty skeleton for {}", obj.ModelHash.data());
+                mLogger->warn("got empty skeleton for {}", obj.ModelHash.data());
                 continue;
             }
 
@@ -35,8 +34,7 @@ void AnimationSystem::Execute(Registry& aRegistry, const float aDelta)
             double animationTime     = std::fmod(animatonTimeTicks, animator.Animation->Duration());
 
             if (animator.FinalBonesMatrices.empty()) {
-                WATO_DBG(
-                    aRegistry,
+                mLogger->debug(
                     "empty final bone vertices, reserving {}",
                     skeleton.Bones.size());
                 animator.FinalBonesMatrices.resize(skeleton.Bones.size());

--- a/src/systems/animation.hpp
+++ b/src/systems/animation.hpp
@@ -16,6 +16,8 @@ class AnimationSystem : public FrameSystem
    public:
     using FrameSystem::FrameSystem;
 
+    const char* Name() const override { return "AnimationSystem"; }
+
    protected:
     void Execute(Registry& aRegistry, float aDelta) override;
 

--- a/src/systems/collision.cpp
+++ b/src/systems/collision.cpp
@@ -77,7 +77,7 @@ void CollisionSystem::projectileHits(
     if (targetCollider) {
         entt::entity targetEntity = colliderMap.at(targetCollider);
 
-        WATO_DBG(aRegistry, "projectile {} hits target {}", projectileEntity, targetEntity);
+        mLogger->debug("projectile {} hits target {}", projectileEntity, targetEntity);
         auto* projectile = aRegistry.try_get<Projectile>(projectileEntity);
         if (!projectile) {
             return;
@@ -92,8 +92,7 @@ void CollisionSystem::projectileHits(
                     aHealth.Health -= projectile->Damage;
                     aHealth.LastHitBy = projectile->OwnerID;
                 });
-                WATO_INFO(
-                    aRegistry,
+                mLogger->info(
                     "projectile {} hit creep {}, health now {}",
                     projectileEntity,
                     targetEntity,
@@ -112,8 +111,7 @@ void CollisionSystem::projectileHits(
                 }
             }
         }
-        WATO_INFO(
-            aRegistry,
+        mLogger->info(
             "marking projectile {} for destruction (target hit)",
             projectileEntity);
         aToDestroy.insert(projectileEntity);
@@ -122,14 +120,12 @@ void CollisionSystem::projectileHits(
         // can get destroy without damaging creep
         auto* projectile = aRegistry.try_get<Projectile>(projectileEntity);
         if (projectile && !aRegistry.valid(projectile->Target)) {
-            WATO_INFO(
-                aRegistry,
+            mLogger->info(
                 "marking projectile {} for destruction (terrain, target invalid)",
                 projectileEntity);
             aToDestroy.insert(projectileEntity);
         } else {
-            WATO_DBG(
-                aRegistry,
+            mLogger->debug(
                 "projectile {} hit terrain but target still valid, ignoring",
                 projectileEntity);
         }
@@ -155,8 +151,7 @@ void CollisionSystem::creepHitsPlayerBase(Registry& aRegistry, const TriggerEven
             aHealth.Health -= creep.Damage;
         });
 
-        WATO_DBG(
-            aRegistry,
+        mLogger->debug(
             "creep hits base, player {} looses {} health, {} left",
             playerEntity,
             creep.Damage,

--- a/src/systems/collision.hpp
+++ b/src/systems/collision.hpp
@@ -16,6 +16,8 @@ class CollisionSystem : public FixedSystem
    public:
     using FixedSystem::FixedSystem;
 
+    const char* Name() const override { return "CollisionSystem"; }
+
    protected:
     void Execute(Registry& aRegistry, std::uint32_t aTick) override;
 

--- a/src/systems/economy.cpp
+++ b/src/systems/economy.cpp
@@ -13,7 +13,7 @@ void EconomySystem::PeriodicExecute(Registry& aRegistry, [[maybe_unused]] std::u
 
     for (auto [entity, player, gold] : aRegistry.view<Player, Gold>().each()) {
         gold.Balance += income.Value;
-        WATO_DBG(aRegistry, "player {} income +{}, balance {}", player.ID, income.Value, gold.Balance);
+        mLogger->debug("player {} income +{}, balance {}", player.ID, income.Value, gold.Balance);
 
         if (auto* server = aRegistry.ctx().find<ENetServer>()) {
             server->BroadcastResponse(

--- a/src/systems/health.cpp
+++ b/src/systems/health.cpp
@@ -18,7 +18,7 @@ void HealthSystem::Execute(Registry& aRegistry, [[maybe_unused]] std::uint32_t a
 {
     for (auto [entity, health, creep] : aRegistry.view<Health, Creep>().each()) {
         if (health.Health <= 0.0f) {
-            WATO_INFO(aRegistry, "creep {} died (health: {})", entity, health.Health);
+            mLogger->info("creep {} died (health: {})", entity, health.Health);
 
             if (health.LastHitBy != PlayerID{}) {
                 auto  killerEntity = FindPlayerEntity(aRegistry, health.LastHitBy);
@@ -45,7 +45,7 @@ void HealthSystem::Execute(Registry& aRegistry, [[maybe_unused]] std::uint32_t a
 
     for (auto [entity, player, health] : group.each()) {
         if (health.Health <= 0.0f) {
-            WATO_INFO(aRegistry, "player {} lost (health: {})", entity, health.Health);
+            mLogger->info("player {} lost (health: {})", entity, health.Health);
 
             // capture before emplace invalidates the reference
             const PlayerID pid = player.ID;

--- a/src/systems/health.hpp
+++ b/src/systems/health.hpp
@@ -13,6 +13,8 @@ class HealthSystem : public FixedSystem
    public:
     using FixedSystem::FixedSystem;
 
+    const char* Name() const override { return "HealthSystem"; }
+
    protected:
     void Execute(Registry& aRegistry, std::uint32_t aTick) override;
 };

--- a/src/systems/input.cpp
+++ b/src/systems/input.cpp
@@ -66,7 +66,7 @@ void InputSystem::createActions(Registry& aRegistry, float aDelta)
         Action action = aBinding.Action;
         action.AddExtraInputInfo(input);
 
-        WATO_TRACE(aRegistry, "got action triggered: {}", action);
+        mLogger->trace("got action triggered: {}", action);
 
         if (action.IsFrameTime()) {
             frameBuf.push_back(action);

--- a/src/systems/input.hpp
+++ b/src/systems/input.hpp
@@ -13,6 +13,8 @@ class InputSystem : public FrameSystem
    public:
     using FrameSystem::FrameSystem;
 
+    const char* Name() const override { return "InputSystem"; }
+
    protected:
     void Execute(Registry& aRegistry, float aDelta) override;
 

--- a/src/systems/network_response.cpp
+++ b/src/systems/network_response.cpp
@@ -70,7 +70,7 @@ void NetworkResponseSystem::onRigidBodyUpdate(const RigidBodyUpdateEvent& aEvent
         }
         void operator()(const std::monostate&) const
         {
-            WATO_INFO(*Reg, "created entity {} (no specific init data)", Update->Entity);
+            Self->mLogger->info("created entity {} (no specific init data)", Update->Entity);
         }
     };
 
@@ -92,8 +92,7 @@ void NetworkResponseSystem::onRigidBodyUpdate(const RigidBodyUpdateEvent& aEvent
                 entt::entity clientEntity = syncMap[update.Entity];
                 registry.destroy(clientEntity);
                 syncMap.erase(update.Entity);
-                WATO_INFO(
-                    registry,
+                mLogger->info(
                     "destroyed entity {} (server entity {})",
                     clientEntity,
                     update.Entity);
@@ -111,16 +110,14 @@ void NetworkResponseSystem::onHealthUpdate(const HealthUpdateEvent& aEvent)
 
     if (syncMap.contains(update.Entity)) {
         entt::entity e = syncMap[update.Entity];
-        WATO_INFO(
-            registry,
+        mLogger->info(
             "received health update for server {}, updating local {} => {}",
             update.Entity,
             e,
             update.Health);
         registry.patch<Health>(e, [&update](Health& aHealth) { aHealth.Health = update.Health; });
     } else {
-        WATO_WARN(
-            registry,
+        mLogger->warn(
             "received health update for server {} with {}, but entity not synced",
             update.Entity,
             update.Health);
@@ -136,16 +133,15 @@ void NetworkResponseSystem::onGoldUpdate(const GoldUpdateEvent& aEvent)
     auto* gold         = registry.try_get<Gold>(playerEntity);
     if (gold) {
         gold->Balance = update.Balance;
-        WATO_DBG(registry, "gold update for player {}: {}", update.Player, update.Balance);
+        mLogger->debug("gold update for player {}: {}", update.Player, update.Balance);
     } else {
-        WATO_WARN(registry, "gold update for player {} but no Gold component", update.Player);
+        mLogger->warn("gold update for player {} but no Gold component", update.Player);
     }
 }
 
 void NetworkResponseSystem::onSyncPayload(const SyncPayloadEvent& aEvent)
 {
-    Registry&   registry = *aEvent.Reg;
-    const auto& payload  = aEvent.Payload;
+    const auto& payload = aEvent.Payload;
 
     if (payload.State.Snapshot.empty()) {
         return;
@@ -155,8 +151,7 @@ void NetworkResponseSystem::onSyncPayload(const SyncPayloadEvent& aEvent)
     Registry              tmp;
     entt::snapshot_loader loader{tmp};
 
-    WATO_TRACE(
-        registry,
+    mLogger->trace(
         "loading state snapshot {} of size {}",
         payload.State.Tick,
         payload.State.Snapshot.size());
@@ -171,18 +166,18 @@ void NetworkResponseSystem::createProjectile(
 {
     auto& syncMap = GetSingletonComponent<EntitySyncMap>(aRegistry);
 
-    WATO_INFO(aRegistry, "got projectile init data");
+    mLogger->info("got projectile init data");
 
     auto sourceTowerIt = syncMap.find(aInit.SourceTower);
     if (sourceTowerIt == syncMap.end()) {
-        WATO_WARN(aRegistry, "source tower {} not found in sync map", aInit.SourceTower);
+        mLogger->warn("source tower {} not found in sync map", aInit.SourceTower);
         return;
     }
 
     entt::entity clientTower    = sourceTowerIt->second;
     auto*        towerTransform = aRegistry.try_get<Transform3D>(clientTower);
     if (!towerTransform) {
-        WATO_WARN(aRegistry, "source tower {} has no transform", clientTower);
+        mLogger->warn("source tower {} has no transform", clientTower);
         return;
     }
 
@@ -202,7 +197,7 @@ void NetworkResponseSystem::createProjectile(
     if (targetIt != syncMap.end()) {
         clientTarget = targetIt->second;
     } else {
-        WATO_ERR(aRegistry, "projectile server target {} unknown", aInit.Target);
+        mLogger->error("projectile server target {} unknown", aInit.Target);
     }
 
     aRegistry
@@ -213,7 +208,7 @@ void NetworkResponseSystem::createProjectile(
 
     syncMap.insert_or_assign(aUpdate.Entity, projectile);
 
-    WATO_INFO(aRegistry, "created projectile {} from server entity {}", projectile, aUpdate.Entity);
+    mLogger->info("created projectile {} from server entity {}", projectile, aUpdate.Entity);
 }
 
 void NetworkResponseSystem::createTower(
@@ -248,7 +243,7 @@ void NetworkResponseSystem::createTower(
 
     syncMap.insert_or_assign(aUpdate.Entity, tower);
 
-    WATO_INFO(aRegistry, "created tower {} from server entity {}", tower, aUpdate.Entity);
+    mLogger->info("created tower {} from server entity {}", tower, aUpdate.Entity);
 }
 
 void NetworkResponseSystem::createCreep(
@@ -287,5 +282,5 @@ void NetworkResponseSystem::createCreep(
 
     syncMap.insert_or_assign(aUpdate.Entity, creep);
 
-    WATO_INFO(aRegistry, "created creep {} from server entity {}", creep, aUpdate.Entity);
+    mLogger->info("created creep {} from server entity {}", creep, aUpdate.Entity);
 }

--- a/src/systems/physics.hpp
+++ b/src/systems/physics.hpp
@@ -13,6 +13,8 @@ class PhysicsSystem : public FixedSystem
    public:
     using FixedSystem::FixedSystem;
 
+    const char* Name() const override { return "PhysicsSystem"; }
+
    protected:
     void Execute(Registry& aRegistry, std::uint32_t aTick) override;
 };
@@ -29,6 +31,8 @@ class UpdateTransformsSytem : public FrameSystem
    public:
     using FrameSystem::FrameSystem;
 
+    const char* Name() const override { return "UpdateTransformsSystem"; }
+
    protected:
     void Execute(Registry& aRegistry, float aFactor) override;
 };
@@ -43,6 +47,8 @@ class SimulationSystem : public FrameSystem
 {
    public:
     using FrameSystem::FrameSystem;
+
+    const char* Name() const override { return "SimulationSystem"; }
 
    protected:
     void Execute(Registry& aRegistry, float aTick) override;

--- a/src/systems/projectile.cpp
+++ b/src/systems/projectile.cpp
@@ -14,7 +14,7 @@ void ProjectileSystem::Execute(Registry& aRegistry, [[maybe_unused]] std::uint32
          aRegistry.view<Projectile, Transform3D, RigidBody>().each()) {
         auto* targetTransform = aRegistry.try_get<Transform3D>(projectile.Target);
         if (!targetTransform) {
-            WATO_TRACE(aRegistry, "projectile has dead target", projectileEntity);
+            mLogger->trace("projectile has dead target", projectileEntity);
             continue;
         }
 

--- a/src/systems/projectile.hpp
+++ b/src/systems/projectile.hpp
@@ -13,6 +13,8 @@ class ProjectileSystem : public FixedSystem
    public:
     using FixedSystem::FixedSystem;
 
+    const char* Name() const override { return "ProjectileSystem"; }
+
    protected:
     void Execute(Registry& aRegistry, std::uint32_t aTick) override;
 };

--- a/src/systems/render.cpp
+++ b/src/systems/render.cpp
@@ -14,22 +14,17 @@
 #include <memory>
 #include <span>
 #include <unordered_map>
-#include <variant>
 
 #include "components/animator.hpp"
 #include "components/camera.hpp"
 #include "components/health.hpp"
 #include "components/imgui.hpp"
+#include "components/light_source.hpp"
 #include "components/model_rotation_offset.hpp"
-#include "components/player.hpp"
+#include "components/placement_mode.hpp"
 #include "components/scene_object.hpp"
 #include "core/menu/menu.hpp"
-#include "core/menu/menu_events.hpp"
-#include "core/net/pocketbase.hpp"
 #include "core/physics/physics.hpp"
-#include "core/sys/log.hpp"
-#include "core/tile.hpp"
-#include "core/types.hpp"
 #include "core/window.hpp"
 #include "imgui_helper.h"
 #include "imgui_hud.hpp"

--- a/src/systems/render.hpp
+++ b/src/systems/render.hpp
@@ -2,11 +2,6 @@
 
 #include <entt/entity/organizer.hpp>
 
-#include "components/light_source.hpp"
-#include "components/placement_mode.hpp"
-#include "components/scene_object.hpp"
-#include "components/transform3d.hpp"
-#include "core/physics/physics.hpp"
 #include "registry/registry.hpp"
 #include "systems/system.hpp"
 
@@ -24,6 +19,8 @@ class RenderSystem : public FrameSystem
    protected:
     void Execute(Registry& aRegistry, float aDelta) override;
 
+    const char* Name() const override { return "RenderSystem"; }
+
    private:
     void updateGridTexture(Registry& aRegistry);
     void renderGrid(Registry& aRegistry);
@@ -40,6 +37,8 @@ class RenderImguiSystem : public FrameSystem
    public:
     using FrameSystem::FrameSystem;
 
+    const char* Name() const override { return "RenderImguiSystem"; }
+
    protected:
     void Execute(Registry& aRegistry, float aDelta) override;
 };
@@ -54,6 +53,8 @@ class CameraSystem : public FrameSystem
 {
    public:
     using FrameSystem::FrameSystem;
+
+    const char* Name() const override { return "CameraSystem"; }
 
    protected:
     void Execute(Registry& aRegistry, float aDelta) override;
@@ -70,6 +71,8 @@ class PhysicsDebugSystem : public FrameSystem
 {
    public:
     using FrameSystem::FrameSystem;
+
+    const char* Name() const override { return "PhysicsDebugSystem"; }
 
    protected:
     void Execute(Registry& aRegistry, float aDelta) override;

--- a/src/systems/rigid_bodies_update.cpp
+++ b/src/systems/rigid_bodies_update.cpp
@@ -21,28 +21,27 @@ void RigidBodiesUpdateSystem::Execute(Registry& aRegistry, [[maybe_unused]] std:
         auto& t  = aRegistry.get<Transform3D>(e);
 
         if (!rb.Body) {
-            WATO_DBG(aRegistry, "rigid body creation for {}", e);
+            mLogger->debug("rigid body creation for {}", e);
             rb.Body  = physics.CreateRigidBody(rb.Params, t);
             c.Handle = physics.AddCollider(rb.Body, c.Params);
 
             colliderToEntity[c.Handle] = e;
         } else {
-            WATO_TRACE(aRegistry, "rigid body update for {}:", e);
+            mLogger->trace("rigid body update for {}:", e);
         }
 
         if (rb.Params.Data != rb.Body->getUserData()) {
-            WATO_TRACE(aRegistry, "   user data");
+            mLogger->trace("   user data");
             rb.Body->setUserData(rb.Params.Data);
         }
 
         if (rb.Params.Type != rb.Body->getType()) {
-            WATO_TRACE(aRegistry, "  body type");
+            mLogger->trace("  body type");
             rb.Body->setType(rb.Params.Type);
         }
 
         if (rb.Params.Type == reactphysics3d::BodyType::KINEMATIC) {
-            WATO_TRACE(
-                aRegistry,
+            mLogger->trace(
                 "  linear velocity: {} * {}",
                 rb.Params.Direction,
                 rb.Params.Velocity);
@@ -50,7 +49,7 @@ void RigidBodiesUpdateSystem::Execute(Registry& aRegistry, [[maybe_unused]] std:
         }
 
         if (c.Params.IsTrigger != c.Handle->getIsTrigger()) {
-            WATO_TRACE(aRegistry, "  is trigger {}", c.Params.IsTrigger);
+            mLogger->trace("  is trigger {}", c.Params.IsTrigger);
             c.Handle->setIsTrigger(c.Params.IsTrigger);
             if (!c.Params.IsTrigger) {
                 c.Handle->setIsSimulationCollider(true);

--- a/src/systems/sync.cpp
+++ b/src/systems/sync.cpp
@@ -89,7 +89,7 @@ void NetworkSyncSystem<ENetServer>::Execute(
     }
 
     for (auto& e : rbDestroyedStorage) {
-        WATO_DBG(aRegistry, "rigid body destroyed for {}", e);
+        mLogger->debug("rigid body destroyed for {}", e);
 
         net.BroadcastResponse(
             GetPlayerIDs(aRegistry),

--- a/src/systems/system.hpp
+++ b/src/systems/system.hpp
@@ -31,6 +31,9 @@ class System : public entt::basic_process<Delta>
     void update(Delta aDelta, void* aData) override
     {
         auto* registry = static_cast<Registry*>(aData);
+        if (!mLogger) {
+            initLogger(*registry);
+        }
         Execute(*registry, aDelta);
     }
 
@@ -38,6 +41,28 @@ class System : public entt::basic_process<Delta>
 
    protected:
     virtual void Execute(Registry& aRegistry, Delta aDelta) = 0;
+
+    Logger mLogger;
+
+   private:
+    void initLogger(const Registry& aRegistry)
+    {
+        const auto& sideLogger = WATO_REG_LOGGER(aRegistry);
+
+        auto name = fmt::format("{}.{}", sideLogger->name(), Name());
+
+        if (auto existing = spdlog::get(name)) {
+            mLogger = existing;
+            return;
+        }
+
+        mLogger = std::make_shared<spdlog::logger>(
+            name,
+            sideLogger->sinks().begin(),
+            sideLogger->sinks().end());
+        mLogger->set_level(sideLogger->level());
+        spdlog::register_logger(mLogger);
+    }
 };
 
 /**

--- a/src/systems/tower_attack.cpp
+++ b/src/systems/tower_attack.cpp
@@ -131,7 +131,12 @@ void TowerAttackSystem::Execute(Registry& aRegistry, [[maybe_unused]] std::uint3
                 glm::identity<glm::quat>(),
                 glm::vec3(0.1f));
 
-            aRegistry.emplace<Projectile>(projectile, attack.Damage, 1.0f, attack.CurrentTarget, owner.ID);
+            aRegistry.emplace<Projectile>(
+                projectile,
+                attack.Damage,
+                1.0f,
+                attack.CurrentTarget,
+                owner.ID);
 
             glm::vec3 direction = glm::normalize(targetTransform->Position - pT.Position);
 
@@ -186,11 +191,10 @@ void TowerAttackSystem::Execute(Registry& aRegistry, [[maybe_unused]] std::uint3
                             },
                     });
             } else {
-                WATO_WARN(aRegistry, "enet server not instanciated");
+                mLogger->warn("enet server not instanciated");
             }
 
-            WATO_DBG(
-                aRegistry,
+            mLogger->debug(
                 "tower {} fired projectile {} at target {}",
                 towerEntity,
                 projectile,

--- a/src/systems/tower_built.cpp
+++ b/src/systems/tower_built.cpp
@@ -28,7 +28,7 @@ void TowerBuiltSystem::Execute(Registry& aRegistry, [[maybe_unused]] std::uint32
     if (storage->empty()) {
         return;
     }
-    WATO_TRACE(aRegistry, "got {} towers built", storage->size());
+    mLogger->trace("got {} towers built", storage->size());
 
     // Collect which player graphs need path recomputation
     std::set<PlayerID> dirtyPlayers;
@@ -56,8 +56,8 @@ void TowerBuiltSystem::Execute(Registry& aRegistry, [[maybe_unused]] std::uint32
             for (auto&& [e, player, transform] : aRegistry.view<Player, Transform3D>().each()) {
                 if (player.ID == pid) {
                     graph.ComputePaths(transform.Position);
-                    WATO_DBG(aRegistry, "{}", graph);
-                    WATO_TRACE(aRegistry, "paths updated for player {}", pid);
+                    mLogger->debug("{}", graph);
+                    mLogger->trace("paths updated for player {}", pid);
                     break;
                 }
             }

--- a/src/systems/ui.cpp
+++ b/src/systems/ui.cpp
@@ -60,7 +60,7 @@ void UISystem::onLogin(const LoginEvent& aEvent)
         }
     });
 
-    WATO_INFO(*reg, "pb.Login() returned (not blocked)");
+    mLogger->info("pb.Login() returned (not blocked)");
 }
 
 void UISystem::onLoginResult(const LoginResultEvent& aEvent)
@@ -73,7 +73,7 @@ void UISystem::onLoginResult(const LoginResultEvent& aEvent)
     if (aEvent.Error.empty()) {
         auto playerID = IDFromHexString<PlayerID>(aEvent.ID);
         if (!playerID) {
-            WATO_ERR(registry, "invalid player ID: '{}'", aEvent.ID);
+            mLogger->error("invalid player ID: '{}'", aEvent.ID);
             return;
         }
 
@@ -92,13 +92,13 @@ void UISystem::onLoginResult(const LoginResultEvent& aEvent)
         auto& netClient = GetSingletonComponent<ENetClient&>(registry);
         netClient.Connect();
 
-        WATO_INFO(registry, "user {} logged in", aEvent.AccountName);
+        mLogger->info("user {} logged in", aEvent.AccountName);
     } else {
         menu.LoginState = LoginState::Failed;
         menu.Error      = aEvent.Error;
         menu.Message.clear();
 
-        WATO_ERR(registry, "login failed: {}", aEvent.Error);
+        mLogger->error("login failed: {}", aEvent.Error);
     }
 }
 
@@ -140,13 +140,13 @@ void UISystem::onRegisterResult(const RegisterResultEvent& aEvent)
         menu.Error.clear();
         menu.State = MenuState::Login;
 
-        WATO_INFO(registry, "user {} registered", aEvent.AccountName);
+        mLogger->info("user {} registered", aEvent.AccountName);
     } else {
         menu.RegisterState = RegisterState::Failed;
         menu.Error         = aEvent.Error;
         menu.Message.clear();
 
-        WATO_ERR(registry, "register failed: {}", aEvent.Error);
+        mLogger->error("register failed: {}", aEvent.Error);
     }
 }
 
@@ -214,7 +214,7 @@ void UISystem::onJoinResult(const JoinResultEvent& aEvent)
     menu.Matchmaking.State    = MatchmakingState::Waiting;
     menu.Matchmaking.RecordId = aEvent.ID;
 
-    WATO_INFO(*reg, "joined matchmaking queue, record id: {}", aEvent.ID);
+    mLogger->info("joined matchmaking queue, record id: {}", aEvent.ID);
 }
 
 void UISystem::onMatchmakingError(const MatchmakingErrorEvent& aEvent)
@@ -226,5 +226,5 @@ void UISystem::onMatchmakingError(const MatchmakingErrorEvent& aEvent)
     menu.Error             = aEvent.Error;
     menu.Message.clear();
 
-    WATO_ERR(registry, "matchmaking error: {}", aEvent.Error);
+    mLogger->error("matchmaking error: {}", aEvent.Error);
 }


### PR DESCRIPTION
Fixes an issue where creeps would not correctly collide with player base:
- Grow base bounding box and center around base's cell
- better graph ToWorld func

Misc fixes:
- add system tag to log
- replace std::function which will be deprecated